### PR TITLE
Add more GPG keyservers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,10 @@ RUN set -ex \
         B9AE9905FFD7803F25714661B63B535A4C206CA9 \
         C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8 \
     ; do \
-        gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
+        gpg --batch --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" || \
+        gpg --batch --keyserver hkp://ipv4.pool.sks-keyservers.net --recv-keys "$key" || \
+        gpg --batch --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" || \
+        gpg --batch --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
     done
 
 ENV NPM_CONFIG_LOGLEVEL info


### PR DESCRIPTION
The container fails to build occasionally when there are bad servers in
the pool. This is similar to how the official node container handles
these issue.